### PR TITLE
Changing default locales to better represent Linux users

### DIFF
--- a/os_installer2/pages/__init__.py
+++ b/os_installer2/pages/__init__.py
@@ -14,10 +14,11 @@
 # Credit: gnome-inital-setup
 default_locales = [
     "en_US.UTF-8",
-    "fr_FR.UTF-8",
     "de_DE.UTF-8",
-    "it_IT.UTF-8",
-    "pt_BR.UTF-8",
+    "fr_FR.UTF-8",
+    "es_ES.UTF-8",
+    "zh_CN.UTF-8",
+    "ja_JP.UTF-8",
     "ru_RU.UTF-8",
-    "es_ES.UTF-8"
+    "ar_EG.UTF-8"
 ]

--- a/os_installer2/pages/__init__.py
+++ b/os_installer2/pages/__init__.py
@@ -14,10 +14,10 @@
 # Credit: gnome-inital-setup
 default_locales = [
     "en_US.UTF-8",
-    "fr_FR.UTF-8",
-    "es_ES.UTF-8",
-    "zh_CN.UTF-8",
-    "ja_JP.UTF-8",
-    "ru_RU.UTF-8",
-    "ar_EG.UTF-8"
+	"fr_FR.UTF-8",
+	"de_DE.UTF-8",
+	"it_IT.UTF-8",
+	"pt_BR.UTF-8",
+	"ru_RU.UTF-8",
+	"es_ES.UTF-8"
 ]

--- a/os_installer2/pages/__init__.py
+++ b/os_installer2/pages/__init__.py
@@ -14,10 +14,10 @@
 # Credit: gnome-inital-setup
 default_locales = [
     "en_US.UTF-8",
-	"fr_FR.UTF-8",
-	"de_DE.UTF-8",
-	"it_IT.UTF-8",
-	"pt_BR.UTF-8",
-	"ru_RU.UTF-8",
-	"es_ES.UTF-8"
+    "fr_FR.UTF-8",
+    "de_DE.UTF-8",
+    "it_IT.UTF-8",
+    "pt_BR.UTF-8",
+    "ru_RU.UTF-8",
+    "es_ES.UTF-8"
 ]


### PR DESCRIPTION
I found the default locales a bit weird, so I did some research what the biggst Linux users are. I know there can't be any reliable data, but [this was the best I found](http://www.linux-netbook.com/linux/linux-counter-map/) (using total users, not per capita). I also changed the order to be alphabetically, so nobody feels neglected - English is still on top 😄 