### PR TITLE
Change Gtk.VBox & Gtk.HBox to Gtk.Box

### DIFF
--- a/os_installer2/mainwindow.py
+++ b/os_installer2/mainwindow.py
@@ -167,7 +167,7 @@ class MainWindow(Gtk.ApplicationWindow):
         self.set_default_size(768, 500)
 
         # Main "install" page
-        self.installer_page = Gtk.VBox(0)
+        self.installer_page = Gtk.Box(Gtk.Orientation.VERTICAL, 0)
         self.installer_stack = Gtk.Stack()
         self.installer_page.pack_start(self.installer_stack, True, True, 0)
 

--- a/os_installer2/mainwindow.py
+++ b/os_installer2/mainwindow.py
@@ -167,7 +167,7 @@ class MainWindow(Gtk.ApplicationWindow):
         self.set_default_size(768, 500)
 
         # Main "install" page
-        self.installer_page = Gtk.Box(Gtk.Orientation.VERTICAL, 0)
+        self.installer_page = Gtk.Box.new(Gtk.Orientation.VERTICAL, 0)
         self.installer_stack = Gtk.Stack()
         self.installer_page.pack_start(self.installer_stack, True, True, 0)
 

--- a/os_installer2/pages/basepage.py
+++ b/os_installer2/pages/basepage.py
@@ -14,11 +14,13 @@
 from gi.repository import Gtk
 
 
-class BasePage(Gtk.VBox):
+class BasePage(Gtk.Box):
     """ Base widget for all page implementations to save on duplication. """
 
     def __init__(self):
-        Gtk.VBox.__init__(self)
+        Gtk.Box.__init__(self)
+
+        self.set_property("orientation", Gtk.Orientation.VERTICAL)
 
         mk = u"<span font-size='x-large'>{}</span>".format(self.get_title())
         lab = Gtk.Label.new(mk)

--- a/os_installer2/pages/basepage.py
+++ b/os_installer2/pages/basepage.py
@@ -18,7 +18,7 @@ class BasePage(Gtk.Box):
     """ Base widget for all page implementations to save on duplication. """
 
     def __init__(self):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL, spacing=0)
 
         mk = u"<span font-size='x-large'>{}</span>".format(self.get_title())
         lab = Gtk.Label.new(mk)

--- a/os_installer2/pages/basepage.py
+++ b/os_installer2/pages/basepage.py
@@ -18,9 +18,7 @@ class BasePage(Gtk.Box):
     """ Base widget for all page implementations to save on duplication. """
 
     def __init__(self):
-        Gtk.Box.__init__(self)
-
-        self.set_property("orientation", Gtk.Orientation.VERTICAL)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
 
         mk = u"<span font-size='x-large'>{}</span>".format(self.get_title())
         lab = Gtk.Label.new(mk)

--- a/os_installer2/pages/complete.py
+++ b/os_installer2/pages/complete.py
@@ -23,7 +23,7 @@ class InstallationCompletePage(BasePage):
     def __init__(self):
         BasePage.__init__(self)
 
-        box = Gtk.VBox(0)
+        box = Gtk.Box(Gtk.Orientation.VERTICAL, 0)
         self.pack_start(box, True, True, 0)
         box.set_border_width(40)
         box.set_valign(Gtk.Align.CENTER)

--- a/os_installer2/pages/complete.py
+++ b/os_installer2/pages/complete.py
@@ -23,7 +23,7 @@ class InstallationCompletePage(BasePage):
     def __init__(self):
         BasePage.__init__(self)
 
-        box = Gtk.Box(Gtk.Orientation.VERTICAL, 0)
+        box = Gtk.Box.new(Gtk.Orientation.VERTICAL, 0)
         self.pack_start(box, True, True, 0)
         box.set_border_width(40)
         box.set_valign(Gtk.Align.CENTER)

--- a/os_installer2/pages/disk_location.py
+++ b/os_installer2/pages/disk_location.py
@@ -18,13 +18,15 @@ from os_installer2.strategy import DiskStrategyManager
 import threading
 
 
-class BrokenWindowsPage(Gtk.VBox):
+class BrokenWindowsPage(Gtk.Box):
     """ Indicate to the user that they booted in the wrong mode """
 
     owner = None
 
     def __init__(self, owner):
-        Gtk.VBox.__init__(self)
+        Gtk.Box.__init__(self)
+        self.set_property("orientation", Gtk.Orientation.VERTICAL)
+
         self.owner = owner
 
         img = Gtk.Image.new_from_icon_name("face-crying-symbolic",
@@ -59,7 +61,7 @@ class BrokenWindowsPage(Gtk.VBox):
         self.owner.stack.set_visible_child_name("chooser")
 
 
-class ChooserPage(Gtk.VBox):
+class ChooserPage(Gtk.Box):
     """ Main chooser UI """
 
     combo = None
@@ -72,7 +74,9 @@ class ChooserPage(Gtk.VBox):
     info = None
 
     def __init__(self):
-        Gtk.VBox.__init__(self)
+        Gtk.Box.__init__(self)
+
+        self.set_property("orientation", Gtk.Orientation.VERTICAL)
         self.set_border_width(40)
 
         # set up the disk selector
@@ -80,7 +84,7 @@ class ChooserPage(Gtk.VBox):
 
         self.pack_start(self.combo, False, False, 0)
 
-        self.strategy_box = Gtk.VBox(0)
+        self.strategy_box = Gtk.Box(Gtk.Orientation.VERTICAL, 0)
         self.strategy_box.set_margin_top(20)
         self.pack_start(self.strategy_box, True, True, 0)
 
@@ -147,11 +151,13 @@ class ChooserPage(Gtk.VBox):
         self.combo.set_active_id(active_id)
 
 
-class WhoopsPage(Gtk.VBox):
+class WhoopsPage(Gtk.Box):
     """ No disks on this system """
 
     def __init__(self):
-        Gtk.VBox.__init__(self)
+        Gtk.Box.__init__(self)
+
+        self.set_property("orientation", Gtk.Orientation.VERTICAL)
 
         img = Gtk.Image.new_from_icon_name("face-crying-symbolic",
                                            Gtk.IconSize.DIALOG)
@@ -171,11 +177,13 @@ class WhoopsPage(Gtk.VBox):
         self.set_halign(Gtk.Align.CENTER)
 
 
-class LoadingPage(Gtk.HBox):
+class LoadingPage(Gtk.Box):
     """ Spinner/load box """
 
     def __init__(self):
-        Gtk.HBox.__init__(self)
+        Gtk.Box.__init__(self)
+
+        self.set_property("orientation", Gtk.Orientation.HORIZONTAL)
 
         self.spinner = Gtk.Spinner()
         self.pack_start(self.spinner, False, False, 10)

--- a/os_installer2/pages/disk_location.py
+++ b/os_installer2/pages/disk_location.py
@@ -24,8 +24,7 @@ class BrokenWindowsPage(Gtk.Box):
     owner = None
 
     def __init__(self, owner):
-        Gtk.Box.__init__(self)
-        self.set_property("orientation", Gtk.Orientation.VERTICAL)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
 
         self.owner = owner
 
@@ -74,7 +73,7 @@ class ChooserPage(Gtk.Box):
     info = None
 
     def __init__(self):
-        Gtk.Box.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
 
         self.set_property("orientation", Gtk.Orientation.VERTICAL)
         self.set_border_width(40)
@@ -84,7 +83,7 @@ class ChooserPage(Gtk.Box):
 
         self.pack_start(self.combo, False, False, 0)
 
-        self.strategy_box = Gtk.Box(Gtk.Orientation.VERTICAL, 0)
+        self.strategy_box = Gtk.Box.new(Gtk.Orientation.VERTICAL, 0)
         self.strategy_box.set_margin_top(20)
         self.pack_start(self.strategy_box, True, True, 0)
 
@@ -155,9 +154,7 @@ class WhoopsPage(Gtk.Box):
     """ No disks on this system """
 
     def __init__(self):
-        Gtk.Box.__init__(self)
-
-        self.set_property("orientation", Gtk.Orientation.VERTICAL)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
 
         img = Gtk.Image.new_from_icon_name("face-crying-symbolic",
                                            Gtk.IconSize.DIALOG)
@@ -181,9 +178,7 @@ class LoadingPage(Gtk.Box):
     """ Spinner/load box """
 
     def __init__(self):
-        Gtk.Box.__init__(self)
-
-        self.set_property("orientation", Gtk.Orientation.HORIZONTAL)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
 
         self.spinner = Gtk.Spinner()
         self.pack_start(self.spinner, False, False, 10)

--- a/os_installer2/pages/disk_location.py
+++ b/os_installer2/pages/disk_location.py
@@ -24,7 +24,7 @@ class BrokenWindowsPage(Gtk.Box):
     owner = None
 
     def __init__(self, owner):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL, spacing=0)
 
         self.owner = owner
 
@@ -73,7 +73,7 @@ class ChooserPage(Gtk.Box):
     info = None
 
     def __init__(self):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL, spacing=0)
 
         self.set_property("orientation", Gtk.Orientation.VERTICAL)
         self.set_border_width(40)
@@ -154,7 +154,7 @@ class WhoopsPage(Gtk.Box):
     """ No disks on this system """
 
     def __init__(self):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL, spacing=0)
 
         img = Gtk.Image.new_from_icon_name("face-crying-symbolic",
                                            Gtk.IconSize.DIALOG)
@@ -178,7 +178,7 @@ class LoadingPage(Gtk.Box):
     """ Spinner/load box """
 
     def __init__(self):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL, spacing=0)
 
         self.spinner = Gtk.Spinner()
         self.pack_start(self.spinner, False, False, 10)

--- a/os_installer2/pages/geoip.py
+++ b/os_installer2/pages/geoip.py
@@ -33,7 +33,7 @@ class InstallerGeoipPage(BasePage):
     def __init__(self):
         BasePage.__init__(self)
 
-        hbox = Gtk.HBox(0)
+        hbox = Gtk.Box(Gtk.Orientation.HORIZONTAL, 0)
         self.pack_start(hbox, True, True, 0)
         hbox.set_margin_top(20)
         hbox.set_border_width(40)

--- a/os_installer2/pages/geoip.py
+++ b/os_installer2/pages/geoip.py
@@ -33,7 +33,7 @@ class InstallerGeoipPage(BasePage):
     def __init__(self):
         BasePage.__init__(self)
 
-        hbox = Gtk.Box(Gtk.Orientation.HORIZONTAL, 0)
+        hbox = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 0)
         self.pack_start(hbox, True, True, 0)
         hbox.set_margin_top(20)
         hbox.set_border_width(40)

--- a/os_installer2/pages/keyboard.py
+++ b/os_installer2/pages/keyboard.py
@@ -23,9 +23,8 @@ class KbLabel(Gtk.Box):
     dname = None
 
     def __init__(self, kb, info):
-        Gtk.Box.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL)
 
-        self.set_property("orientation", Gtk.Orientation.HORIZONTAL)
         self.kb = kb
 
         lab = Gtk.Label("")

--- a/os_installer2/pages/keyboard.py
+++ b/os_installer2/pages/keyboard.py
@@ -16,14 +16,16 @@ from gi.repository import Gtk, GnomeDesktop
 import subprocess
 
 
-class KbLabel(Gtk.HBox):
+class KbLabel(Gtk.Box):
     """ View label for locales, save code duping """
 
     kb = None
     dname = None
 
     def __init__(self, kb, info):
-        Gtk.HBox.__init__(self)
+        Gtk.Box.__init__(self)
+
+        self.set_property("orientation", Gtk.Orientation.HORIZONTAL)
         self.kb = kb
 
         lab = Gtk.Label("")

--- a/os_installer2/pages/keyboard.py
+++ b/os_installer2/pages/keyboard.py
@@ -23,7 +23,7 @@ class KbLabel(Gtk.Box):
     dname = None
 
     def __init__(self, kb, info):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
 
         self.kb = kb
 

--- a/os_installer2/pages/partitioning.py
+++ b/os_installer2/pages/partitioning.py
@@ -64,7 +64,7 @@ class ManualPage(Gtk.Box):
     cur_strategy = None
 
     def __init__(self):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL, spacing=0)
 
         lab = Gtk.Label("Select custom mount points to use with Solus from "
                         "the available partition selection below.\n"
@@ -431,7 +431,7 @@ class DualBootPage(Gtk.Box):
     info = None
 
     def __init__(self):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL, spacing=0)
 
         self.set_border_width(40)
 
@@ -559,7 +559,7 @@ class AdvancedOptionsPage(Gtk.Box):
     pw_grid = None
 
     def __init__(self):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL, spacing=0)
 
         self.set_border_width(40)
         self.info_label = Gtk.Label("<big>Advanced installation options</big>")

--- a/os_installer2/pages/partitioning.py
+++ b/os_installer2/pages/partitioning.py
@@ -64,9 +64,7 @@ class ManualPage(Gtk.Box):
     cur_strategy = None
 
     def __init__(self):
-        Gtk.Box.__init__(self)
-
-        self.set_property("orientation", Gtk.Orientation.VERTICAL)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
 
         lab = Gtk.Label("Select custom mount points to use with Solus from "
                         "the available partition selection below.\n"
@@ -433,9 +431,8 @@ class DualBootPage(Gtk.Box):
     info = None
 
     def __init__(self):
-        Gtk.Box.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
 
-        self.set_property("orientation", Gtk.Orientation.VERTICAL)
         self.set_border_width(40)
 
         self.info_label = Gtk.Label.new("")
@@ -444,7 +441,7 @@ class DualBootPage(Gtk.Box):
         self.info_label.set_halign(Gtk.Align.START)
 
         # Construct dual-boot row
-        hbox = Gtk.Box(Gtk.Orientation.HORIZONTAL, 0)
+        hbox = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 0)
         hbox.set_margin_top(20)
         self.pack_start(hbox, False, False, 0)
 
@@ -470,7 +467,7 @@ class DualBootPage(Gtk.Box):
         lab2.get_style_context().add_class("dim-label")
 
         # Now start our row
-        hbox = Gtk.Box(Gtk.Orientation.HORIZONTAL, 0)
+        hbox = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 0)
         hbox.set_margin_top(20)
         self.pack_start(hbox, False, False, 0)
 
@@ -562,9 +559,8 @@ class AdvancedOptionsPage(Gtk.Box):
     pw_grid = None
 
     def __init__(self):
-        Gtk.Box.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
 
-        self.set_property("orientation", Gtk.Orientation.VERTICAL)
         self.set_border_width(40)
         self.info_label = Gtk.Label("<big>Advanced installation options</big>")
         self.info_label.set_margin_bottom(10)

--- a/os_installer2/pages/partitioning.py
+++ b/os_installer2/pages/partitioning.py
@@ -50,7 +50,7 @@ class SwapPartition(GObject.Object):
         self.part = part
 
 
-class ManualPage(Gtk.VBox):
+class ManualPage(Gtk.Box):
     """ Manual partitioning page, mostly TreeView with gparted proxy """
 
     info = None
@@ -64,7 +64,9 @@ class ManualPage(Gtk.VBox):
     cur_strategy = None
 
     def __init__(self):
-        Gtk.VBox.__init__(self)
+        Gtk.Box.__init__(self)
+
+        self.set_property("orientation", Gtk.Orientation.VERTICAL)
 
         lab = Gtk.Label("Select custom mount points to use with Solus from "
                         "the available partition selection below.\n"
@@ -418,7 +420,7 @@ class ManualPage(Gtk.VBox):
         self.info.owner.set_can_next(True)
 
 
-class DualBootPage(Gtk.VBox):
+class DualBootPage(Gtk.Box):
     """ Used to manage the dual boot configuration settings,
         essentially we're just here to resize the users partititon
         and make room for Solus. """
@@ -431,8 +433,9 @@ class DualBootPage(Gtk.VBox):
     info = None
 
     def __init__(self):
-        Gtk.VBox.__init__(self)
+        Gtk.Box.__init__(self)
 
+        self.set_property("orientation", Gtk.Orientation.VERTICAL)
         self.set_border_width(40)
 
         self.info_label = Gtk.Label.new("")
@@ -441,7 +444,7 @@ class DualBootPage(Gtk.VBox):
         self.info_label.set_halign(Gtk.Align.START)
 
         # Construct dual-boot row
-        hbox = Gtk.HBox(0)
+        hbox = Gtk.Box(Gtk.Orientation.HORIZONTAL, 0)
         hbox.set_margin_top(20)
         self.pack_start(hbox, False, False, 0)
 
@@ -467,7 +470,7 @@ class DualBootPage(Gtk.VBox):
         lab2.get_style_context().add_class("dim-label")
 
         # Now start our row
-        hbox = Gtk.HBox(0)
+        hbox = Gtk.Box(Gtk.Orientation.HORIZONTAL, 0)
         hbox.set_margin_top(20)
         self.pack_start(hbox, False, False, 0)
 
@@ -545,7 +548,7 @@ class DualBootPage(Gtk.VBox):
         self.info_label.set_markup(l)
 
 
-class AdvancedOptionsPage(Gtk.VBox):
+class AdvancedOptionsPage(Gtk.Box):
     """ Advanced options for full disk installs, enabling LVM + encryption """
 
     info_label = None
@@ -559,7 +562,9 @@ class AdvancedOptionsPage(Gtk.VBox):
     pw_grid = None
 
     def __init__(self):
-        Gtk.VBox.__init__(self)
+        Gtk.Box.__init__(self)
+
+        self.set_property("orientation", Gtk.Orientation.VERTICAL)
         self.set_border_width(40)
         self.info_label = Gtk.Label("<big>Advanced installation options</big>")
         self.info_label.set_margin_bottom(10)

--- a/os_installer2/pages/progress.py
+++ b/os_installer2/pages/progress.py
@@ -94,7 +94,7 @@ class InstallerProgressPage(BasePage):
         BasePage.__init__(self)
 
         self.error_msgs = []
-        box = Gtk.Box(Gtk.Orientation.VERTICAL, 0)
+        box = Gtk.Box.new(Gtk.Orientation.VERTICAL, 0)
         box.set_border_width(20)
         self.pack_end(box, False, False, 0)
 

--- a/os_installer2/pages/progress.py
+++ b/os_installer2/pages/progress.py
@@ -94,7 +94,7 @@ class InstallerProgressPage(BasePage):
         BasePage.__init__(self)
 
         self.error_msgs = []
-        box = Gtk.VBox(0)
+        box = Gtk.Box(Gtk.Orientation.VERTICAL, 0)
         box.set_border_width(20)
         self.pack_end(box, False, False, 0)
 

--- a/os_installer2/pages/summary.py
+++ b/os_installer2/pages/summary.py
@@ -22,7 +22,8 @@ class FramedHeader(Gtk.Frame):
 
     def __init__(self, icon_name, title):
         Gtk.Frame.__init__(self)
-        box = Gtk.Box(Gtk.Orientation.HORIZONTAL, 0)
+
+        box = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 0)
 
         sz = Gtk.IconSize.DIALOG
         image = Gtk.Image.new_from_icon_name(icon_name, sz)
@@ -38,7 +39,7 @@ class FramedHeader(Gtk.Frame):
         label.set_valign(Gtk.Align.START)
         label.set_property("margin", 10)
 
-        self.vbox = Gtk.Box(Gtk.Orientation.VERTICAL, 0)
+        self.vbox = Gtk.Box.new(Gtk.Orientation.VERTICAL, 0)
         box.pack_end(self.vbox, False, False, 0)
         self.vbox.set_property("margin", 10)
 
@@ -66,7 +67,7 @@ class InstallerSummaryPage(BasePage):
         self.pack_start(scroll, True, True, 0)
         scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
 
-        items = Gtk.Box(Gtk.Orientation.VERTICAL, 0)
+        items = Gtk.Box.new(Gtk.Orientation.VERTICAL, 0)
         scroll.add(items)
         scroll.set_overlay_scrolling(False)
         self.locale_details = FramedHeader(

--- a/os_installer2/pages/summary.py
+++ b/os_installer2/pages/summary.py
@@ -22,7 +22,7 @@ class FramedHeader(Gtk.Frame):
 
     def __init__(self, icon_name, title):
         Gtk.Frame.__init__(self)
-        box = Gtk.HBox(0)
+        box = Gtk.Box(Gtk.Orientation.HORIZONTAL, 0)
 
         sz = Gtk.IconSize.DIALOG
         image = Gtk.Image.new_from_icon_name(icon_name, sz)
@@ -38,7 +38,7 @@ class FramedHeader(Gtk.Frame):
         label.set_valign(Gtk.Align.START)
         label.set_property("margin", 10)
 
-        self.vbox = Gtk.VBox(0)
+        self.vbox = Gtk.Box(Gtk.Orientation.VERTICAL, 0)
         box.pack_end(self.vbox, False, False, 0)
         self.vbox.set_property("margin", 10)
 
@@ -66,7 +66,7 @@ class InstallerSummaryPage(BasePage):
         self.pack_start(scroll, True, True, 0)
         scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
 
-        items = Gtk.VBox(0)
+        items = Gtk.Box(Gtk.Orientation.VERTICAL, 0)
         scroll.add(items)
         scroll.set_overlay_scrolling(False)
         self.locale_details = FramedHeader(

--- a/os_installer2/pages/system.py
+++ b/os_installer2/pages/system.py
@@ -38,7 +38,7 @@ class InstallerSystemPage(BasePage):
 
         wid_group = Gtk.SizeGroup(Gtk.SizeGroupMode.HORIZONTAL)
 
-        mbox = Gtk.VBox(0)
+        mbox = Gtk.Box(Gtk.Orientation.VERTICAL, 0)
         mbox.set_margin_top(40)
         self.pack_start(mbox, False, False, 0)
         mbox.set_halign(Gtk.Align.CENTER)

--- a/os_installer2/pages/system.py
+++ b/os_installer2/pages/system.py
@@ -38,7 +38,7 @@ class InstallerSystemPage(BasePage):
 
         wid_group = Gtk.SizeGroup(Gtk.SizeGroupMode.HORIZONTAL)
 
-        mbox = Gtk.Box(Gtk.Orientation.VERTICAL, 0)
+        mbox = Gtk.Box.new(Gtk.Orientation.VERTICAL, 0)
         mbox.set_margin_top(40)
         self.pack_start(mbox, False, False, 0)
         mbox.set_halign(Gtk.Align.CENTER)

--- a/os_installer2/pages/users.py
+++ b/os_installer2/pages/users.py
@@ -20,11 +20,13 @@ LABEL_COLUMN = 0
 DATA_COLUMN = 1
 
 
-class UserPanel(Gtk.VBox):
+class UserPanel(Gtk.Box):
     """Userpanel. Represents a user. Whoda thunk it. """
 
     def __init__(self, user):
-        Gtk.VBox.__init__(self)
+        Gtk.Box.__init__(self)
+
+        self.set_property("orientation", Gtk.Orientation.VERTICAL)
 
         self.user = user
 
@@ -287,7 +289,8 @@ class InstallerUsersPage(BasePage):
         self.stack.set_transition_type(Gtk.StackTransitionType.SLIDE_UP_DOWN)
         self.pack_start(self.stack, True, True, 0)
 
-        main_page = Gtk.VBox()
+        main_page = Gtk.Box()
+        main_page.set_property("orientation", Gtk.Orientation.VERTICAL)
         main_page.pack_start(scroller, True, True, 0)
         main_page.pack_start(toolbar, False, False, 0)
         main_page.set_border_width(40)

--- a/os_installer2/pages/users.py
+++ b/os_installer2/pages/users.py
@@ -24,9 +24,7 @@ class UserPanel(Gtk.Box):
     """Userpanel. Represents a user. Whoda thunk it. """
 
     def __init__(self, user):
-        Gtk.Box.__init__(self)
-
-        self.set_property("orientation", Gtk.Orientation.VERTICAL)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
 
         self.user = user
 
@@ -289,8 +287,7 @@ class InstallerUsersPage(BasePage):
         self.stack.set_transition_type(Gtk.StackTransitionType.SLIDE_UP_DOWN)
         self.pack_start(self.stack, True, True, 0)
 
-        main_page = Gtk.Box()
-        main_page.set_property("orientation", Gtk.Orientation.VERTICAL)
+        main_page = Gtk.Box.new(Gtk.Orientation.VERTICAL, 0)
         main_page.pack_start(scroller, True, True, 0)
         main_page.pack_start(toolbar, False, False, 0)
         main_page.set_border_width(40)

--- a/os_installer2/pages/users.py
+++ b/os_installer2/pages/users.py
@@ -24,7 +24,7 @@ class UserPanel(Gtk.Box):
     """Userpanel. Represents a user. Whoda thunk it. """
 
     def __init__(self, user):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL, spacing=0)
 
         self.user = user
 


### PR DESCRIPTION
With the upcoming Gtk 4 changes, Gtk.VBox and Gtk.HBox have been deprecated in favor of Gtk.Box with an orientation.