### PR TITLE
Add xfs support to the installer

### DIFF
--- a/os_installer2/diskman.py
+++ b/os_installer2/diskman.py
@@ -199,7 +199,7 @@ class SystemPartition(GObject.Object):
             if self.min_size < self.usedspace:
                 self.min_size = self.usedspace
             self.resizable = True
-            break        
+            break
 
     def __init__(self, partition, mount_point, dm):
         GObject.GObject.__init__(self)

--- a/os_installer2/diskman.py
+++ b/os_installer2/diskman.py
@@ -199,7 +199,7 @@ class SystemPartition(GObject.Object):
             if self.min_size < self.usedspace:
                 self.min_size = self.usedspace
             self.resizable = True
-            break
+            break        
 
     def __init__(self, partition, mount_point, dm):
         GObject.GObject.__init__(self)

--- a/os_installer2/diskops.py
+++ b/os_installer2/diskops.py
@@ -686,7 +686,7 @@ class DiskOpFormatRoot(DiskOpFormatPartition):
     """ Format the root partition """
 
     def __init__(self, device, part, format_type):
-        self.fstype = fstype
+        self.format_type = format_type
         DiskOpFormatPartition.__init__(self, device, part, format_type)
 
     def describe(self):
@@ -812,18 +812,18 @@ class DiskOpUseHome(BaseDiskOp):
     """ Use an existing home paritition """
 
     home_part = None
-    home_part_fs = None
+    part_type = None
     path = None
 
-    def __init__(self, device, home_part, home_part_fs):
+    def __init__(self, device, home_part, part_type):
         BaseDiskOp.__init__(self, device)
         self.home_part = home_part
         self.path = self.home_part.path
-        self.home_part_fs = home_part_fs
+        self.part_type = part_type
 
     def describe(self):
         return "Use {} ({}) as home partition".format(self.home_part.path,
-                                                      self.home_part_fs)
+                                                      self.part_type)
 
     def apply(self, disk, simulate):
         """ Can't actually fail here. """

--- a/os_installer2/diskops.py
+++ b/os_installer2/diskops.py
@@ -700,7 +700,8 @@ class DiskOpFormatRoot(DiskOpFormatPartition):
         if self.format_type == "ext4":
             cmd = "mkfs.ext4 -F {}".format(self.part.path)
         elif self.format_type == "xfs":
-            cmd = "xfs -f {}".format(self.part.path)
+            cmd = "mkfs.xfs -f {}".format(self.part.path)
+            
         try:
             subprocess.check_call(cmd, shell=True)
         except Exception as e:
@@ -726,7 +727,8 @@ class DiskOpFormatRootLate(DiskOpFormatPartition):
         if self.format_type == "ext4":
             cmd = "mkfs.ext4 -F {}".format(self.part.path)
         elif self.format_type == "xfs":
-            cmd = "xfs -f {}".format(self.part.path)
+            cmd = "mkfs.xfs -f {}".format(self.part.path)
+
         try:
             subprocess.check_call(cmd, shell=True)
         except Exception as e:
@@ -798,7 +800,7 @@ class DiskOpFormatHome(DiskOpFormatPartition):
         if self.format_type == "ext4":
             cmd = "mkfs.ext4 -F {}".format(self.part.path)
         elif self.format_type == "xfs":
-            cmd = "xfs -f {}".format(self.part.path)
+            cmd = "mkfs.xfs -f {}".format(self.part.path)
         
         try:
             subprocess.check_call(cmd, shell=True)

--- a/os_installer2/diskops.py
+++ b/os_installer2/diskops.py
@@ -685,8 +685,9 @@ class DiskOpFormatPartition(BaseDiskOp):
 class DiskOpFormatRoot(DiskOpFormatPartition):
     """ Format the root partition """
 
-    def __init__(self, device, part):
-        DiskOpFormatPartition.__init__(self, device, part, "ext4")
+    def __init__(self, device, part, format_type):
+        self.fstype = fstype
+        DiskOpFormatPartition.__init__(self, device, part, format_type)
 
     def describe(self):
         return "Format {} as {} root partition".format(
@@ -696,7 +697,10 @@ class DiskOpFormatRoot(DiskOpFormatPartition):
         if simulate:
             return True
 
-        cmd = "mkfs.ext4 -F {}".format(self.part.path)
+        if self.format_type == "ext4"
+            cmd = "mkfs.ext4 -F {}".format(self.part.path)
+        elif self.format_type == "xfs"
+            cmd = "xfs -f {}".format(self.part.path)
         try:
             subprocess.check_call(cmd, shell=True)
         except Exception as e:
@@ -708,8 +712,8 @@ class DiskOpFormatRoot(DiskOpFormatPartition):
 class DiskOpFormatRootLate(DiskOpFormatPartition):
     """ Format the root partition """
 
-    def __init__(self, device, part):
-        DiskOpFormatPartition.__init__(self, device, part, "ext4")
+    def __init__(self, device, part, format_type):
+        DiskOpFormatPartition.__init__(self, device, part, format_type)
 
     def describe(self):
         return "Format {} as {} root partition".format(
@@ -719,7 +723,10 @@ class DiskOpFormatRootLate(DiskOpFormatPartition):
         return True
 
     def apply_format(self, disk):
-        cmd = "mkfs.ext4 -F {}".format(self.part.path)
+        if self.format_type == "ext4"
+            cmd = "mkfs.ext4 -F {}".format(self.part.path)
+        elif self.format_type == "xfs"
+            cmd = "xfs -f {}".format(self.part.path)
         try:
             subprocess.check_call(cmd, shell=True)
         except Exception as e:
@@ -777,11 +784,8 @@ class DiskOpFormatSwapLate(DiskOpFormatPartition):
 class DiskOpFormatHome(DiskOpFormatPartition):
     """ Format the home partition """
 
-    fstype = None
-
-    def __init__(self, device, part, fstype):
-        DiskOpFormatPartition.__init__(self, device, part, fstype)
-        self.fstype = fstype
+    def __init__(self, device, part, format_type):
+        DiskOpFormatPartition.__init__(self, device, part, format_type)
 
     def describe(self):
         return "Format {} as {} home partition".format(
@@ -791,10 +795,10 @@ class DiskOpFormatHome(DiskOpFormatPartition):
         if simulate:
             return True
 
-        if self.fstype == "ext4":
+        if self.format_type == "ext4"
             cmd = "mkfs.ext4 -F {}".format(self.part.path)
-        elif self.fstype == "xfs":
-            cmd = "mkfs.xfs -f {}".format(self.part.path)
+        elif self.format_type == "xfs"
+            cmd = "xfs -f {}".format(self.part.path)
         
         try:
             subprocess.check_call(cmd, shell=True)

--- a/os_installer2/diskops.py
+++ b/os_installer2/diskops.py
@@ -777,8 +777,11 @@ class DiskOpFormatSwapLate(DiskOpFormatPartition):
 class DiskOpFormatHome(DiskOpFormatPartition):
     """ Format the home partition """
 
-    def __init__(self, device, part):
-        DiskOpFormatPartition.__init__(self, device, part, "ext4")
+    fstype = None
+
+    def __init__(self, device, part, fstype):
+        DiskOpFormatPartition.__init__(self, device, part, fstype)
+        self.fstype = fstype
 
     def describe(self):
         return "Format {} as {} home partition".format(
@@ -788,7 +791,11 @@ class DiskOpFormatHome(DiskOpFormatPartition):
         if simulate:
             return True
 
-        cmd = "mkfs.ext4 -F {}".format(self.part.path)
+        if self.fstype == "ext4":
+            cmd = "mkfs.ext4 -F {}".format(self.part.path)
+        elif self.fstype == "xfs":
+            cmd = "mkfs.xfs -f {}".format(self.part.path)
+        
         try:
             subprocess.check_call(cmd, shell=True)
         except Exception as e:

--- a/os_installer2/diskops.py
+++ b/os_installer2/diskops.py
@@ -697,9 +697,9 @@ class DiskOpFormatRoot(DiskOpFormatPartition):
         if simulate:
             return True
 
-        if self.format_type == "ext4"
+        if self.format_type == "ext4":
             cmd = "mkfs.ext4 -F {}".format(self.part.path)
-        elif self.format_type == "xfs"
+        elif self.format_type == "xfs":
             cmd = "xfs -f {}".format(self.part.path)
         try:
             subprocess.check_call(cmd, shell=True)
@@ -723,9 +723,9 @@ class DiskOpFormatRootLate(DiskOpFormatPartition):
         return True
 
     def apply_format(self, disk):
-        if self.format_type == "ext4"
+        if self.format_type == "ext4":
             cmd = "mkfs.ext4 -F {}".format(self.part.path)
-        elif self.format_type == "xfs"
+        elif self.format_type == "xfs":
             cmd = "xfs -f {}".format(self.part.path)
         try:
             subprocess.check_call(cmd, shell=True)
@@ -795,9 +795,9 @@ class DiskOpFormatHome(DiskOpFormatPartition):
         if simulate:
             return True
 
-        if self.format_type == "ext4"
+        if self.format_type == "ext4":
             cmd = "mkfs.ext4 -F {}".format(self.part.path)
-        elif self.format_type == "xfs"
+        elif self.format_type == "xfs":
             cmd = "xfs -f {}".format(self.part.path)
         
         try:

--- a/os_installer2/pages/partitioning.py
+++ b/os_installer2/pages/partitioning.py
@@ -157,6 +157,7 @@ class ManualPage(Gtk.Box):
         model = self.treeview.get_model()
         row = model[path]
         fs = row[INDEX_PARTITION_TYPE]
+        row[INDEX_PARTITION_TYPE] = text
         self.update_selection()
 
     def on_format_toggled(self, widget, path):

--- a/os_installer2/pages/partitioning.py
+++ b/os_installer2/pages/partitioning.py
@@ -89,6 +89,10 @@ class ManualPage(Gtk.Box):
         self.store_mountpoints.append(["swap", "swap"])
         self.store_mountpoints.append([NO_HAZ_ASSIGN, NO_HAZ_ASSIGN])
 
+        self.store_filesystems = Gtk.ListStore(str, str)
+        self.store_filesystems.append(["ext4", "ext4"])
+        self.store_filesystems.append(["xfs", "xfs"])
+
         self.treeview = Gtk.TreeView()
         self.scrl = Gtk.ScrolledWindow(None, None)
         self.scrl.add(self.treeview)
@@ -103,7 +107,14 @@ class ManualPage(Gtk.Box):
         self.column3.add_attribute(ren, "markup", INDEX_PARTITION_PATH)
         self.treeview.append_column(self.column3)
 
-        self.column4 = Gtk.TreeViewColumn("Current filesystem", ren)
+        # filesystem selection
+        ren = Gtk.CellRendererCombo()
+        ren.set_property("editable", True)
+        ren.set_property("model", self.store_filesystems)
+        ren.set_property("has-entry", False)
+        ren.set_property("text-column", 0)
+        ren.connect("edited", self.on_filesystem_changed)
+        self.column4 = Gtk.TreeViewColumn("Filesystem", ren)
         self.column4.add_attribute(ren, "markup", INDEX_PARTITION_TYPE)
         self.treeview.append_column(self.column4)
 
@@ -141,6 +152,12 @@ class ManualPage(Gtk.Box):
         self.column9 = Gtk.TreeViewColumn("Free space", ren)
         self.column9.add_attribute(ren, "markup", INDEX_PARTITION_FREE_SPACE)
         self.treeview.append_column(self.column9)
+
+    def on_filesystem_changed(self, widget, path, text):
+        model = self.treeview.get_model()
+        row = model[path]
+        fs = row[INDEX_PARTITION_TYPE]
+        self.update_selection()
 
     def on_format_toggled(self, widget, path):
         model = self.treeview.get_model()

--- a/os_installer2/pages/partitioning.py
+++ b/os_installer2/pages/partitioning.py
@@ -420,16 +420,18 @@ class ManualPage(Gtk.Box):
                     swap_obj = swap_obj.part
             elif point == '/home':
                 home_format = row[INDEX_PARTITION_FORMAT]
+                home_fs = row[INDEX_PARTITION_TYPE]
                 home_obj = row[INDEX_PARTITION_OBJECT]
                 if isinstance(home_obj, SystemPartition):
                     home_obj = home_obj.partition
             elif point == '/':
                 root_obj = row[INDEX_PARTITION_OBJECT]
+                root_fs = row[INDEX_PARTITION_TYPE]
                 if isinstance(root_obj, SystemPartition):
                     root_obj = root_obj.partition
 
-        self.info.strategy.set_root_partition(root_obj)
-        self.info.strategy.set_home_partition(home_obj, home_format)
+        self.info.strategy.set_root_partition(root_obj, root_fs)
+        self.info.strategy.set_home_partition(home_obj, home_format, home_fs)
         self.info.strategy.set_swap_partition(swap_obj, swap_format)
         # Now we can go forward.
         self.selection_label.set_markup(labe)

--- a/os_installer2/pages/partitioning.py
+++ b/os_installer2/pages/partitioning.py
@@ -34,7 +34,7 @@ INDEX_PARTITION_FREE_SPACE = 6
 INDEX_PARTITION_OBJECT = 7
 INDEX_PARTITION_SIZE_NUM = 8
 
-ACCEPTABLE_FS_TYPES = ["ext", "ext2", "ext3", "ext4"]
+ACCEPTABLE_FS_TYPES = ["ext", "ext2", "ext3", "ext4", "xfs"]
 NO_HAZ_ASSIGN = "Unassigned"
 
 

--- a/os_installer2/postinstall.py
+++ b/os_installer2/postinstall.py
@@ -563,6 +563,7 @@ class PostInstallFstab(PostInstallStep):
         appends = []
 
         ext4_ops = "rw,relatime,errors=remount-ro"
+        xfs_ops = "rw,relatime,inode64,nobarrier"
 
         for op in strat.get_operations():
             # TODO: Add custom mountpoints here!
@@ -573,7 +574,10 @@ class PostInstallFstab(PostInstallStep):
                 desc = "# {} at time of installation".format(op.home_part.path)
                 i = "UUID={}\t/home\t{}\t{}\t0\t2"
                 appends.append(desc)
-                appends.append(i.format(huuid, fs, ext4_ops))
+                if fs == "ext4":
+                    appends.append(i.format(huuid, fs, ext4_ops))
+                elif fs == "xfs":
+                    appends.append(i.format(huuid, fs, xfs_ops))
                 continue
             elif isinstance(op, DiskOpCreateBoot):
                 buuid = get_part_uuid(op.part.path)
@@ -581,7 +585,10 @@ class PostInstallFstab(PostInstallStep):
                 desc = "# {} at time of installation".format(op.part.path)
                 i = "UUID={}\t/boot\t{}\t{}\t0\t2"
                 appends.append(desc)
-                appends.append(i.format(buuid, fs, ext4_ops))
+                if fs == "ext4":
+                    appends.append(i.format(buuid, fs, ext4_ops))
+                elif fs == "xfs":
+                    appends.append(i.format(buuid, fs, xfs_ops))
                 continue
             if disk.type == "gpt" and strat.is_uefi():
                 continue
@@ -606,9 +613,10 @@ class PostInstallFstab(PostInstallStep):
         # Add the root partition last
         root = strat.get_root_partition()
         uuid = get_part_uuid(root)
+        root_fs = strat.root_fstype
         appends.append("# {} at time of installation".format(root))
 
-        appends.append("UUID={}\t/\text4\t{}\t0\t1".format(uuid, ext4_ops))
+        appends.append("UUID={}\t/\t{}\t{}\t0\t1".format(uuid, root_fs, ext4_ops))
 
         fp = os.path.join(self.installer.get_installer_target_filesystem(),
                           "etc/fstab")

--- a/os_installer2/strategy.py
+++ b/os_installer2/strategy.py
@@ -363,7 +363,7 @@ class EmptyDiskStrategy(DiskStrategy):
             self.push_operation(lv_op)
             # Format the root partition
             self.push_operation(DiskOpFormatRootLate(
-                self.drive.device, DummyPart(lv_op.path)))
+                self.drive.device, DummyPart(lv_op.path), "ext4"))
 
             return
 
@@ -668,7 +668,7 @@ class ReplaceOSStrategy(DiskStrategy):
 
         # Create root
         op = DiskOpFormatRoot(self.drive.device,
-                              self.candidate_part.partition)
+                              self.candidate_part.partition, "ext4")
         self.push_operation(op)
 
     def get_root_partition(self):
@@ -687,6 +687,7 @@ class UserPartitionStrategy(DiskStrategy):
     priority = 10
 
     root_part = None
+    root_fstype = None
     home_part = None
     home_format = False
     home_fstype = None
@@ -709,7 +710,7 @@ class UserPartitionStrategy(DiskStrategy):
     def set_root_partition(self, part, fstype):
         """ Set the root partition to use """
         self.root_part = part
-        self.home_fstype = fstype
+        self.root_fstype = fstype
 
     def set_home_partition(self, part, fmt, fstype):
         """ Set the home partition to use and maybe format """
@@ -759,7 +760,7 @@ class UserPartitionStrategy(DiskStrategy):
         if not self.root_part:
             return
         dev = self.find_device(info.prober, self.root_part)
-        self.push_operation(DiskOpFormatRoot(dev, self.root_part))
+        self.push_operation(DiskOpFormatRoot(dev, self.root_part, self.root_fstype))
 
         if self.swap_part:
             dev = self.find_device(info.prober, self.swap_part)

--- a/os_installer2/strategy.py
+++ b/os_installer2/strategy.py
@@ -689,6 +689,7 @@ class UserPartitionStrategy(DiskStrategy):
     root_part = None
     home_part = None
     home_format = False
+    home_fstype = None
     swap_part = None
     swap_format = False
 
@@ -709,10 +710,11 @@ class UserPartitionStrategy(DiskStrategy):
         """ Set the root partition to use """
         self.root_part = part
 
-    def set_home_partition(self, part, fmt):
+    def set_home_partition(self, part, fmt, fstype):
         """ Set the home partition to use and maybe format """
         self.home_part = part
         self.home_format = fmt
+        self.home_fstype = fstype
 
     def set_swap_partition(self, part, fmt):
         """ Set the swap partition to use and maybe format """
@@ -768,11 +770,11 @@ class UserPartitionStrategy(DiskStrategy):
         if self.home_part:
             dev = self.find_device(info.prober, self.home_part)
             if not self.home_format:
-                fmt = self.find_format(info.prober, self.home_part)
-                self.push_operation(DiskOpUseHome(dev, self.home_part, fmt))
+                self.home_fstype = self.find_format(info.prober, self.home_part)
+                self.push_operation(DiskOpUseHome(dev, self.home_part, self.home_fstype))
             else:
-                self.push_operation(DiskOpFormatHome(dev, self.home_part))
-                self.push_operation(DiskOpUseHome(dev, self.home_part, "ext4"))
+                self.push_operation(DiskOpFormatHome(dev, self.home_part, self.home_fstype))
+                self.push_operation(DiskOpUseHome(dev, self.home_part, self.home_fstype))
 
 
 class DiskStrategyManager:

--- a/os_installer2/strategy.py
+++ b/os_installer2/strategy.py
@@ -706,9 +706,10 @@ class UserPartitionStrategy(DiskStrategy):
                 return op.part.path
         return None
 
-    def set_root_partition(self, part):
+    def set_root_partition(self, part, fstype):
         """ Set the root partition to use """
         self.root_part = part
+        self.home_fstype = fstype
 
     def set_home_partition(self, part, fmt, fstype):
         """ Set the home partition to use and maybe format """


### PR DESCRIPTION
Can't test a full system install, as I'm not sure how to generate a new installation image with this repo, but I can confirm the installer makes xfs partitions when requested, and I made ext4 the default when doing anything else.

Please let me know what needs to change. Haven't done much python, so it may be a little newbish.